### PR TITLE
[Feat] 이미지 스트리밍 기능 구현 및 ServerRequestCacheWebFilter 비활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     runtimeOnly 'mysql:mysql-connector-java:8.0.33'
+
+    // Spring Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/todo/config/SecurityConfig.java
+++ b/src/main/java/com/todo/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/users/**",
                                 "/api/posts/**",
-                                "/api/image/**",
+                                "/api/images/**",
                                 "/api/gemini/**",
                                 "/api/hello",
                                 "/api/delayed-response"

--- a/src/main/java/com/todo/config/SecurityConfig.java
+++ b/src/main/java/com/todo/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.todo.jwt.JwtAuthenticationFilter;
 import com.todo.jwt.JwtTokenProvider;
 import com.todo.user.service.ReactiveUserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.reactive.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
@@ -16,7 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
-import org.springframework.util.PathMatcher;
+
 
 @Configuration
 @EnableWebFluxSecurity
@@ -33,6 +32,15 @@ public class SecurityConfig {
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
                 .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+
+                /*
+                Spring Security의 요청 캐싱 기능을 비활성화합니다.
+                이는 인증되지 않은 사용자가 보호된 리소스에 접근했을 때,
+                로그인 성공 후 원래 요청했던 페이지로 자동으로 리다이렉션하는 기능을 끕니다.
+                API 서버와 같이 리다이렉션이 필요 없는 경우에 사용됩니다.
+                */
+                .requestCache(ServerHttpSecurity.RequestCacheSpec::disable)
+
                 // 인증에 따른 접근 가능 여부 설정
                 .authorizeExchange(exchanges -> exchanges
                         // Spring Actuator 접근 URL 허용
@@ -50,13 +58,17 @@ public class SecurityConfig {
                                 "/api/users/**",
                                 "/api/posts/**",
                                 "/api/image/**",
-                                "/api/gemini/**"
+                                "/api/gemini/**",
+                                "/api/hello",
+                                "/api/delayed-response"
                         ).permitAll()
                         // 위에 명시된 경로를 제외한 모든 요청은 인증된 사용자만 접근할 수 있다.
                         .anyExchange().authenticated()
                 )
+
                 // JWT를 사용한 세션리스(stateless) 인증이므로, 세션 저장소를 사용하지 않도록 설정한다.
                 .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+
                 // SecurityWebFiltersOrder.AUTHENTICATION 위치에 JwtAuthenticationFilter를 추가한다.
                 // 이 필터는 HTTP 요청 헤더에서 JWT 토큰을 추출하고, 토큰의 유효성을 검사하여 인증 객체(Authentication)를 생성한다.
                 .addFilterAt(new JwtAuthenticationFilter(tokenProvider), SecurityWebFiltersOrder.AUTHENTICATION)

--- a/src/main/java/com/todo/config/SecurityConfig.java
+++ b/src/main/java/com/todo/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.todo.jwt.JwtAuthenticationFilter;
 import com.todo.jwt.JwtTokenProvider;
 import com.todo.user.service.ReactiveUserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.reactive.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
@@ -15,6 +16,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import org.springframework.util.PathMatcher;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -33,6 +35,8 @@ public class SecurityConfig {
                 .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
                 // 인증에 따른 접근 가능 여부 설정
                 .authorizeExchange(exchanges -> exchanges
+                        // Spring Actuator 접근 URL 허용
+                        .pathMatchers("/actuator/**").permitAll()
                         // Swagger 접근에 필요한 URL
                         .pathMatchers(
                                 "/v3/api-docs/**",

--- a/src/main/java/com/todo/controller/ImageSendController.java
+++ b/src/main/java/com/todo/controller/ImageSendController.java
@@ -16,12 +16,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.BufferOverflowStrategy;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.time.Duration;
 
 @Slf4j
 @RestController
@@ -106,18 +107,47 @@ public class ImageSendController {
 
 
     /**
-     * 이런식으로 여러 개의 REST API URL을 보내면 클라이언트에서 이것으로 다시 요청을 보내도록 하는 것이다.
+     * 클라이언트에게 SSE(Server-Sent Events)를 통해 이미지 조회 URL 목록을 스트리밍한다.
+     * <br>
+     * {@code limitRate} 오퍼레이터를 사용하여 클라이언트의 처리 속도에 맞춰
+     * 백프레셔(backpressure)를 적용하고 데이터 전송 속도를 제어한다.
      *
-     * @implNote 프론트(클라이언트)에서 SSE를 받는 로직을 따로 구현해야 한다.
+     * @return 이미지 조회 URL을 포함하는 {@link Flux<String>}
+     * @implNote 클라이언트(브라우저)는 SSE를 통해 이 URL들을 수신한 후,
+     * 개별적으로 이미지 콘텐츠를 요청하는 로직을 구현해야 합니다.
      */
-    @GetMapping(value = "/flux", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/flux/limit-rate", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> getImageUrls() {
-        // 실제로는 데이터베이스나 파일 시스템에서 이미지 목록을 가져와서
-        // Flux로 변환하여 보낼 수 있습니다.
+        // 예시 데이터: 실제로는 DB 조회나 파일 시스템 접근을 통해 동적으로 URL을 생성할 수 있다.
         return Flux.just(
-                "/api/images/webflux.png",
-                "/api/images/docker.png",
-                "/api/images/swagger.png"
-        ).delayElements(Duration.ofSeconds(1)); // 예시를 위해 1초 간격으로 보냄
+                        "/api/images/webflux.png",
+                        "/api/images/docker.png",
+                        "/api/images/swagger.png"
+                )
+                .limitRate(2)                     // 클라이언트가 한 번에 최대 2개의 데이터를 요청하도록 백프레셔 적용
+                .subscribeOn(Schedulers.boundedElastic());  // I/O 작업을 위한 별도 스레드에서 실행
+    }
+
+    /**
+     * 클라이언트에게 SSE(Server-Sent Events)를 통해 이미지 조회 URL 목록을 스트리밍한다.
+     * <p>
+     * {@code onBackpressureBuffer} 오퍼레이터를 사용하여 생산자가 소비자보다 빠를 경우
+     * 데이터를 버퍼에 저장하고, 버퍼가 가득 차면 가장 최신 데이터를 버려
+     * 백프레셔(backpressure)를 처리한다.
+     *
+     * @return 이미지 조회 URL을 포함하는 {@link Flux<String>}
+     * @implNote 클라이언트(브라우저)는 SSE를 통해 이 URL들을 수신한 후, 개별적으로 이미지 콘텐츠를 요청하는 로직을 구현해야 합니다.
+     */
+    @GetMapping(value = "/flux/buffer", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> getImageUrlsBuffer() {
+        // 예시 데이터: 실제로는 DB 조회나 파일 시스템 접근을 통해 동적으로 URL을 생성할 수 있습니다.
+        return Flux.just(
+                        "/api/images/webflux.png",
+                        "/api/images/docker.png",
+                        "/api/images/swagger.png"
+                )
+                // 버퍼 크기를 10으로 설정하고, 버퍼 오버플로우 시 최신 데이터를 버림
+                .onBackpressureBuffer(10, BufferOverflowStrategy.DROP_LATEST)
+                .subscribeOn(Schedulers.boundedElastic()); // I/O 작업을 위한 별도 스레드에서 실행
     }
 }

--- a/src/main/java/com/todo/controller/ImageSendController.java
+++ b/src/main/java/com/todo/controller/ImageSendController.java
@@ -68,8 +68,8 @@ public class ImageSendController {
     public Flux<String> getImageUrls() {
         // 예시 데이터: 실제로는 DB 조회나 파일 시스템 접근을 통해 동적으로 URL을 생성할 수 있다.
         return imageService.getAllImagePath()
-                .limitRate(2)                     // 클라이언트가 한 번에 최대 2개의 데이터를 요청하도록 백프레셔 적용
-                .subscribeOn(Schedulers.boundedElastic());  // I/O 작업을 위한 별도 스레드에서 실행
+                .limitRate(2);             // 클라이언트가 한 번에 최대 2개의 데이터를 요청하도록 백프레셔 적용
+
     }
 
     /**

--- a/src/main/java/com/todo/controller/ImageSendController.java
+++ b/src/main/java/com/todo/controller/ImageSendController.java
@@ -1,15 +1,10 @@
 package com.todo.controller;
 
-import com.todo.exception.CustomException;
-import com.todo.exception.dto.ErrorMessage;
-import com.todo.image.ImagePathValidator;
+import com.todo.image.ImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,36 +17,20 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/images")
 @RequiredArgsConstructor
 public class ImageSendController {
-
-    private final ResourceLoader resourceLoader;
-    private final ResourcePatternResolver resourcePatternResolver;
-    private final ImagePathValidator imagePathValidator;
-    private final String locationPattern = "classpath:img/";
+    private final ImageService imageService;
 
     /**
      * Resource를 사용한 정적 이미지 전송
      */
     @GetMapping(produces = MediaType.IMAGE_PNG_VALUE)
     public Mono<Resource> getImage() {
-        String imagePath = locationPattern + "webflux.png";
-
-        // resourceLoader.getResource()는 존재하지 않는 파일도 Resource 객체를 반환하므로,
-        // .exists()로 실제로 파일이 있는지 확인하는 것이 안전합니다.
-        Resource imageResource = resourceLoader.getResource(imagePath);
-
-        if (!imageResource.exists()) {
-            // 파일을 찾지 못했을 경우 404 Not Found 에러를 반환
-            return Mono.error(new CustomException(ErrorMessage.NOT_FOUND_IMAGE, "Image not found: " + imagePath));
-        }
-
-        return Mono.just(imageResource);
+        return imageService.getImage("webflux.png");
     }
 
     /**
@@ -61,26 +40,7 @@ public class ImageSendController {
      */
     @GetMapping(value = "/{image:.+\\.png}", produces = MediaType.IMAGE_PNG_VALUE)
     public Mono<Resource> getImage(@PathVariable String image) {
-        String fileName = Paths.get(image).getFileName().toString();
-
-        // 유효하지 않은 요청이라면 오류를 발생시킴
-        if (!imagePathValidator.isValidPath(fileName)) {
-            return Mono.error(new CustomException(
-                    ErrorMessage.INVALID_IMAGE_PATH,
-                    "유효한 이미지 요청이 아닙니다.")
-            );
-        }
-
-        // resourceLoader.getResource()는 존재하지 않는 파일도 Resource 객체를 반환하므로,
-        // .exists()로 실제로 파일이 있는지 확인하는 것이 안전합니다.
-        Resource imageResource = resourceLoader.getResource(locationPattern + image);
-
-        if (!imageResource.exists()) {
-            // 파일을 찾지 못했을 경우 404 Not Found 에러를 반환
-            return Mono.error(new CustomException(ErrorMessage.NOT_FOUND_IMAGE, "Image not found: " + fileName));
-        }
-
-        return Mono.just(imageResource);
+        return imageService.getImage(image);
     }
 
     /**
@@ -90,19 +50,7 @@ public class ImageSendController {
      */
     @GetMapping(value = "/stream", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public Flux<DataBuffer> streamImage() throws IOException {
-        // ResourceLoader를 ResourcePatternResolver로 캐스팅하여 와일드카드를 지원하게 함
-        Resource[] resources = resourcePatternResolver.getResources(locationPattern);
-
-        // 찾은 모든 리소스를 Flux로 변환
-        return Flux.fromArray(resources)
-                .flatMap(resource -> {
-                    // 각 리소스를 DataBuffer 스트림으로 읽어옴
-                    return DataBufferUtils.read(
-                            resource,
-                            new DefaultDataBufferFactory(),
-                            1024
-                    );
-                });
+        return imageService.getAllImageByBuffer();
     }
 
 
@@ -119,11 +67,7 @@ public class ImageSendController {
     @GetMapping(value = "/flux/limit-rate", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> getImageUrls() {
         // 예시 데이터: 실제로는 DB 조회나 파일 시스템 접근을 통해 동적으로 URL을 생성할 수 있다.
-        return Flux.just(
-                        "/api/images/webflux.png",
-                        "/api/images/docker.png",
-                        "/api/images/swagger.png"
-                )
+        return imageService.getAllImagePath()
                 .limitRate(2)                     // 클라이언트가 한 번에 최대 2개의 데이터를 요청하도록 백프레셔 적용
                 .subscribeOn(Schedulers.boundedElastic());  // I/O 작업을 위한 별도 스레드에서 실행
     }
@@ -141,11 +85,7 @@ public class ImageSendController {
     @GetMapping(value = "/flux/buffer", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> getImageUrlsBuffer() {
         // 예시 데이터: 실제로는 DB 조회나 파일 시스템 접근을 통해 동적으로 URL을 생성할 수 있습니다.
-        return Flux.just(
-                        "/api/images/webflux.png",
-                        "/api/images/docker.png",
-                        "/api/images/swagger.png"
-                )
+        return imageService.getAllImagePath()
                 // 버퍼 크기를 10으로 설정하고, 버퍼 오버플로우 시 최신 데이터를 버림
                 .onBackpressureBuffer(10, BufferOverflowStrategy.DROP_LATEST)
                 .subscribeOn(Schedulers.boundedElastic()); // I/O 작업을 위한 별도 스레드에서 실행

--- a/src/main/java/com/todo/image/ImageService.java
+++ b/src/main/java/com/todo/image/ImageService.java
@@ -52,7 +52,7 @@ public class ImageService {
     /**
      * 모든 이미지를 버퍼에 담아서 가져오는 메소드
      */
-    public Flux<DataBuffer> getAllImageByBuffer() throws IOException {
+    public Flux<DataBuffer> getAllImageByBuffer() {
         final Resource[] resources;
 
         // 이미지 리소스를 가져옴

--- a/src/main/java/com/todo/image/ImageService.java
+++ b/src/main/java/com/todo/image/ImageService.java
@@ -40,7 +40,7 @@ public class ImageService {
             );
         }
 
-        Resource imageResource = resourceLoader.getResource(locationPattern + image);
+        Resource imageResource = resourceLoader.getResource(locationPattern + fileName);
 
         if (!imageResource.exists()) {
             // 파일을 찾지 못했을 경우 404 Not Found 에러를 반환

--- a/src/main/java/com/todo/image/ImageService.java
+++ b/src/main/java/com/todo/image/ImageService.java
@@ -1,0 +1,83 @@
+package com.todo.image;
+
+import com.todo.exception.CustomException;
+import com.todo.exception.dto.ErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final ResourceLoader resourceLoader;
+    private final ImagePathValidator imagePathValidator;
+    private final String locationPattern = "classpath:img/";
+    private final ResourcePatternResolver resourcePatternResolver;
+
+    /**
+     * 이미지명으로 이미지를 가져올 수 있는 메소드
+     *
+     * @param image 가져올 이미지의 파일명
+     * */
+    public Mono<Resource> getImage(String image) {
+        String fileName = Paths.get(image).getFileName().toString();
+
+        // 유효하지 않은 요청이라면 오류를 발생시킴
+        if (!imagePathValidator.isValidPath(fileName)) {
+            return Mono.error(new CustomException(
+                    ErrorMessage.INVALID_IMAGE_PATH,
+                    "유효한 이미지 요청이 아닙니다.")
+            );
+        }
+
+        Resource imageResource = resourceLoader.getResource(locationPattern + image);
+
+        if (!imageResource.exists()) {
+            // 파일을 찾지 못했을 경우 404 Not Found 에러를 반환
+            return Mono.error(new CustomException(ErrorMessage.NOT_FOUND_IMAGE, "Image not found: " + fileName));
+        }
+        return Mono.just(imageResource);
+    }
+
+    /**
+     * 모든 이미지를 버퍼에 담아서 가져오는 메소드
+     * */
+    public Flux<DataBuffer> getAllImageByBuffer() throws IOException {
+        // ResourceLoader를 ResourcePatternResolver로 캐스팅하여 와일드카드를 지원하게 함
+        Resource[] resources = resourcePatternResolver.getResources(locationPattern);
+
+        // 찾은 모든 리소스를 Flux로 변환
+        return Flux.fromArray(resources)
+                .flatMap(resource -> {
+                    // 각 리소스를 DataBuffer 스트림으로 읽어옴
+                    return DataBufferUtils.read(
+                            resource,
+                            new DefaultDataBufferFactory(),
+                            1024
+                    );
+                });
+    }
+
+    /**
+     * 애플리케이션에 저장된 이미지를 가져올 수 있는 REST API URL을 반환하는 메소드.
+     *
+     * @implNote 이미지가 세 개 밖에 없기 때문에 이대로 명시해둠
+     * */
+    public Flux<String> getAllImagePath() {
+        return Flux.just(
+                "/api/images/webflux.png",
+                "/api/images/docker.png",
+                "/api/images/swagger.png"
+        );
+    }
+}

--- a/src/main/java/com/todo/user/service/ReactiveUserDetailsServiceImpl.java
+++ b/src/main/java/com/todo/user/service/ReactiveUserDetailsServiceImpl.java
@@ -16,16 +16,16 @@ public class ReactiveUserDetailsServiceImpl implements ReactiveUserDetailsServic
     @Override
     public Mono<UserDetails> findByUsername(String username) {
         return userRepository.findByUsername(username)
-            .map(this::convertUserToUserDetails);
+                .map(this::convertUserToUserDetails);
     }
 
 
     // User 엔티티를 UserDetails로 변환하는 헬퍼 메서드
     private UserDetails convertUserToUserDetails(User user) {
         return org.springframework.security.core.userdetails.User
-            .withUsername(user.getUsername())
-            .password(user.getPassword()) // 이미 인코딩된 비밀번호
-            .roles(user.getRoles().split(","))
-            .build();
+                .withUsername(user.getUsername())
+                .password(user.getPassword()) // 이미 인코딩된 비밀번호
+                .roles(user.getRoles().split(","))
+                .build();
     }
 }

--- a/src/main/java/com/todo/user/service/UserService.java
+++ b/src/main/java/com/todo/user/service/UserService.java
@@ -155,7 +155,7 @@ public class UserService {
     @Transactional
     public Mono<Long> deleteUsingTemplate(Long id) {
         return template.delete(
-                        Query.query(Criteria.where("id").is(String.valueOf(id))),
+                        Query.query(Criteria.where("id").is(id)),
                         User.class
                 )
                 .flatMap(count -> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,17 @@ spring:
     baseline-on-migrate: true
     clean-disabled: false # flyway.cleanDisabled 속성 비활성화
 
+# Spring Actuator 설정
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+# /actuator/health: 애플리케이션 상태 확인
+# /actuator/info: 애플리케이션에 대한 임의의 정보 표시
+# /actuator/metrics: JVM, CPU, Tomcat 등의 대한 메트링 정보 제공
+# /actuator/loggers: 애플리케이션의 로거 수준을 확인하고 동적으로 변경 가능
+# /actuator/env: 환경 변수, 시스템 속성 등 스프링 환경에 대한 정보를 보여준다. (보안에 민감한 정보 노출 가능 주의)
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
@@ -32,8 +43,8 @@ springdoc:
 
 gemini:
   api:
-    url: [Gemini API 요청 URL]
-    key: [Gemini API Key]
+    url: [제미나이 요청 URL]
+    key: [제미나이 API KEY]
 
 jwt:
   secret-key: dGhpcy1pcy1hLXNlY3JldC1rZXktZm9yLWp3dC10b2tlbi1hbmQtd2ViZmx1eA==


### PR DESCRIPTION
# 이미지 스트리밍 구현

* SSE로 클라이언트에게 이미지를 요청할 수 있는 URL을 보냄. 이미지를 요청하는 로직은 클라이언트에서 구현해야 함.
* `ImageSendController`에서 서비스 로직을 담지 않고 구현함.
    * 책임 분리를 수행할 것.

# ServerRequestCacheWebFilter 비활성화
* 기존에 모든 요청이 컨트롤러에 오기 전에 스레드가 parallel로 바뀌는 동작이 있었음.
* 이는 ServerRequestCacheWebFilter 에서 WebSession을 생성할 때 스레드를 parallel로 바꾸기 때문임.
* 하지만 스레드가 바뀌는 것은 컨텍스트에 저장된 인증 정보를 분실할 수 있는 위험을 가짐.
* 따라서 설정을 비활성화함으로써 인증 정보를 분실하지 않도록 함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 모니터링(Actuator) 의존성 추가 및 모든 Actuator 엔드포인트 웹 노출 활성화.
  * 보안 정책으로 공개 엔드포인트 확장(/actuator/**, /api/hello, /api/delayed-response) 및 무상태 인증 적용.
  * 이미지 기능 개선: 이미지 서비스 도입, SSE 스트리밍 경로/백프레셔 최적화(/flux/limit-rate, /flux/buffer).

* **스타일**
  * 사용자 상세 서비스 일부 포맷 정리(로직 미변경).

* **작업**
  * CRUD 경로에 운영 로그 강화.
  * Gemini 구성값 플레이스홀더 갱신.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->